### PR TITLE
Improve git clone speed by use shallow-clone

### DIFF
--- a/Sources/Git/Git.swift
+++ b/Sources/Git/Git.swift
@@ -5,7 +5,7 @@ public struct Git {
     public init() {}
 
     public var clone: (String, String?) -> Void = { gitURL, location in
-        var command = "git clone \(gitURL)"
+        var command = "git clone --depth 1 \(gitURL)"
         if let location = location {
             command += " \(location)"
         }


### PR DESCRIPTION
Clone repository is heavily if repository size are large.
Run `git clone` command with `--depth 1` option (a.k.a shallow clone), speed up to this task.